### PR TITLE
Add missing base install operations for avali

### DIFF
--- a/1.4/Patches/ImplantPatch.xml
+++ b/1.4/Patches/ImplantPatch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationAdd">
+		<xpath>/Defs/RecipeDef[@Name="SurgeryInstallImplantBase"]/recipeUsers</xpath>
+		<value>
+			<li>RVFFA_Avali</li>
+		</value>
+	</Operation>
+</Patch>


### PR DESCRIPTION
Avali don't have the ability to replace their own organs or utilize prosthetics, which makes working with them harder than intended. This patch should fix that.